### PR TITLE
Redirect to legacy user pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,3 +16,30 @@ chrome.webRequest.onBeforeRequest.addListener(
   },
   ["blocking"]
 )
+chrome.webRequest.onBeforeRequest.addListener(
+  function(details) {
+    var urlParser = document.createElement("a");
+    urlParser.href = details.url;
+    var pathname = urlParser.pathname;
+    
+    //redirect /user/* and /user/*/ to /user/*/overview
+    if (pathname.match(/\/user\/[\w-]+\/?$/)) {
+      var tail = "overview";
+      if (pathname.lastIndexOf("/") != pathname.length - 1) tail = "/" + tail;
+        
+      return {redirectUrl: details.url + tail};
+    }
+  },
+  {
+    urls: [
+      "*://reddit.com/user/*",
+      "*://old.reddit.com/user/*",
+      "*://www.reddit.com/user/*",
+      "*://np.reddit.com/user/*",
+      "*://new.reddit.com/user/*",
+      "*://pay.reddit.com/user/*"
+    ],
+    types: ["main_frame", "sub_frame", "stylesheet", "script", "image", "object", "xmlhttprequest", "other"]
+  },
+  ["blocking"]
+)

--- a/background.js
+++ b/background.js
@@ -2,27 +2,15 @@ const oldReddit = "https://old.reddit.com"
 
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
-    return {redirectUrl: oldReddit + details.url.match(/^https?:\/\/[^\/]+([\S\s]*)/)[1]}
-  },
-  {
-    urls: [
-      "*://reddit.com/*",
-      "*://www.reddit.com/*",
-      "*://np.reddit.com/*",
-      "*://new.reddit.com/*",
-      "*://pay.reddit.com/*"
-    ],
-    types: ["main_frame", "sub_frame", "stylesheet", "script", "image", "object", "xmlhttprequest", "other"]
-  },
-  ["blocking"]
-)
-chrome.webRequest.onBeforeRequest.addListener(
-  function(details) {
     var urlParser = document.createElement("a");
     urlParser.href = details.url;
-    var pathname = urlParser.pathname;
+    
+    //redirect to old.reddit.com
+    if (urlParser.hostname != "old.reddit.com")
+      return {redirectUrl: oldReddit + details.url.match(/^https?:\/\/[^\/]+([\S\s]*)/)[1]};
     
     //redirect /user/* and /user/*/ to /user/*/overview
+    var pathname = urlParser.pathname;
     if (pathname.match(/\/user\/[\w-]+\/?$/)) {
       var tail = "overview";
       if (pathname.lastIndexOf("/") != pathname.length - 1) tail = "/" + tail;
@@ -32,12 +20,8 @@ chrome.webRequest.onBeforeRequest.addListener(
   },
   {
     urls: [
-      "*://reddit.com/user/*",
-      "*://old.reddit.com/user/*",
-      "*://www.reddit.com/user/*",
-      "*://np.reddit.com/user/*",
-      "*://new.reddit.com/user/*",
-      "*://pay.reddit.com/user/*"
+      "*://reddit.com/*",
+      "*://*.reddit.com/*"
     ],
     types: ["main_frame", "sub_frame", "stylesheet", "script", "image", "object", "xmlhttprequest", "other"]
   },

--- a/background.js
+++ b/background.js
@@ -27,7 +27,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       var tail = "overview";
       if (pathname.lastIndexOf("/") != pathname.length - 1) tail = "/" + tail;
         
-      return {redirectUrl: details.url + tail};
+      return {redirectUrl: urlParser.origin + urlParser.pathname + tail + urlParser.search};
     }
   },
   {

--- a/background.js
+++ b/background.js
@@ -1,4 +1,5 @@
 const oldReddit = "https://old.reddit.com"
+const excludedSubdomains = ["blog.reddit.com", "oauth.reddit.com", "out.reddit.com"];
 
 chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
@@ -6,7 +7,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     urlParser.href = details.url;
     
     //redirect to old.reddit.com
-    if (urlParser.hostname != "old.reddit.com")
+    if (urlParser.hostname != "old.reddit.com" && excludedSubdomains.indexOf(urlParser.hostname) == -1)
       return {redirectUrl: oldReddit + details.url.match(/^https?:\/\/[^\/]+([\S\s]*)/)[1]};
     
     //redirect /user/* and /user/*/ to /user/*/overview

--- a/manifest.json
+++ b/manifest.json
@@ -12,10 +12,6 @@
     "webRequest",
     "webRequestBlocking",
     "*://reddit.com/*",
-    "*://old.reddit.com/*",
-    "*://www.reddit.com/*",
-    "*://np.reddit.com/*",
-    "*://new.reddit.com/*",
-    "*://pay.reddit.com/*"
+    "*://*.reddit.com/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
     "webRequest",
     "webRequestBlocking",
     "*://reddit.com/*",
+    "*://old.reddit.com/*",
     "*://www.reddit.com/*",
     "*://np.reddit.com/*",
     "*://new.reddit.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Old Reddit Redirect",
   "description": "Ensure Reddit always loads the old design",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "manifest_version": 2,
   "background": {"scripts":["background.js"]},
   "icons": {


### PR DESCRIPTION
Reddit user pages are immune to the `old` subdomain style override and therefore require their own redirection procedure. This allows the user to browse user pages without having to look at the new design.

I decided against updating the version field in manifest.json because I'm unfamiliar with the current version naming conventions.

The code also leaves much to be desired in terms of DRY programming practices, sorry about that.