### PR TITLE
Remove pay.reddit.com from permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Old Reddit Redirect",
   "description": "Ensure Reddit always loads the old design",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "manifest_version": 2,
   "background": {"scripts":["background.js"]},
   "icons": {
@@ -14,7 +14,6 @@
     "*://reddit.com/*",
     "*://www.reddit.com/*",
     "*://np.reddit.com/*",
-    "*://new.reddit.com/*",
-    "*://pay.reddit.com/*"
+    "*://new.reddit.com/*"
   ]
 }


### PR DESCRIPTION
pay.reddit.com was removed as a redirect from background.js but the url was left in the permission. This commit removes that.