### PR TITLE
README.md: Removed langage code in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Chrome extension](https://chrome.google.com/webstore/detail/old-reddit-redirect/dneaehbmnbhcippjikoajpoabadpodje)
 
-[Firefox extension](https://addons.mozilla.org/en-GB/firefox/addon/old-reddit-redirect/)
+[Firefox extension](https://addons.mozilla.org//firefox/addon/old-reddit-redirect/)
 
 Dislike Reddit's redesign? Old Reddit Redirect will ensure that you always load the old (old.reddit.com) design instead.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Chrome extension](https://chrome.google.com/webstore/detail/old-reddit-redirect/dneaehbmnbhcippjikoajpoabadpodje)
 
-[Firefox extension](https://addons.mozilla.org//firefox/addon/old-reddit-redirect/)
+[Firefox extension](https://addons.mozilla.org/firefox/addon/old-reddit-redirect)
 
 Dislike Reddit's redesign? Old Reddit Redirect will ensure that you always load the old (old.reddit.com) design instead.
 


### PR DESCRIPTION
addons.mozilla.org should figure out the user's language itself.

An alternative would be `...org/firefox...` instead of `...org//firefox...`, but, I guess, it will check whether `firefox` is a language code instead of an empty string. (Both work.)