### PR TITLE
Exclude new.reddit.com (background.js)

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,8 +16,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     urls: [
       "*://reddit.com/*",
       "*://www.reddit.com/*",
-      "*://np.reddit.com/*",
-      "*://new.reddit.com/*",
+      "*://np.reddit.com/*"
     ],
     types: [
       "main_frame",


### PR DESCRIPTION
new.reddit.com should not redirect, as there are some times where I need new reddit and do not want to disable ORR.