### PR TITLE
Exclude new.reddit.com (manifest.json)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,6 @@
     "webRequestBlocking",
     "*://reddit.com/*",
     "*://www.reddit.com/*",
-    "*://np.reddit.com/*",
-    "*://new.reddit.com/*"
+    "*://np.reddit.com/*"
   ]
 }


### PR DESCRIPTION
new.reddit.com should not redirect, as there are some times where I need new reddit and do not want to disable ORR.