### PR TITLE
Exclude draft posts from redirect

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,6 +6,9 @@ const excludedPaths = [
   "/topics",
   "/community-points",
 ];
+const excludedPatterns = [
+  "^/user/[A-Za-z0-9_-]+/draft/",
+];
 
 chrome.webRequest.onBeforeRequest.addListener(
   function (details) {
@@ -15,6 +18,10 @@ chrome.webRequest.onBeforeRequest.addListener(
 
     for (const path of excludedPaths) {
       if (url.pathname.indexOf(path) === 0) return;
+    }
+
+    for (const pattern of excludedPatterns) {
+      if (url.pathname.search(pattern) !== -1) return;
     }
 
     if (url.pathname.indexOf("/gallery") === 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Old Reddit Redirect",
   "description": "Ensure Reddit always loads the old design",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "manifest_version": 2,
   "background": { "scripts": ["background.js"] },
   "icons": {


### PR DESCRIPTION
Fixes #48, using a pattern match to find a draft post, since `/draft` isn't the first bit of the URL.

Tested locally using https://www.reddit.com/user/Wires77/draft/6ee064d6-758f-11ec-9997-16fcaccecb26 (must be signed in to access draft links)

The middle regex matches valid characters for a Reddit username.

Let me know if you don't want the version updated in this PR and I can remove it (or you can, since you can edit this PR)