### PR TITLE
don't redirect links to r/place canvas

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,5 @@
 const oldReddit = "https://old.reddit.com";
+const newReddit = "https://new.reddit.com";
 const excludedPaths = [
   "/poll",
   "/rpan",
@@ -10,6 +11,10 @@ const excludedPaths = [
 chrome.webRequest.onBeforeRequest.addListener(
   function (details) {
     const url = new URL(details.url);
+
+    if (url.pathname === "/r/place/" && url.search.indexOf("cx=") !== -1) {
+      return { redirectUrl: newReddit + url.pathname + url.search + url.hash };
+    }
 
     if (url.hostname === "old.reddit.com") return;
 


### PR DESCRIPTION
This allows viewing & interacting with the canvas on r/place (as old.reddit.com does not appear to support it)
It only redirects links to locations on the canvas; posts in /r/place, as well as the /r/place homepage are not redirected.
(The latter may or may not be the correct approach)

Let me know if I need to change something. PR currently untested as I am lazy.

Closes #65