### PR TITLE
feat: drop Accept header from i.redd.it requests

### DIFF
--- a/background.js
+++ b/background.js
@@ -44,3 +44,33 @@ chrome.webRequest.onBeforeRequest.addListener(
   },
   ["blocking"]
 );
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  function (details) {
+    const url = new URL(details.url);
+
+    if (url.hostname === "i.redd.it") {
+      const headers = details.requestHeaders.filter(h => h.name.toLowerCase() !== "accept");
+      return { requestHeaders: headers };
+    }
+  },
+  {
+    urls: [
+      "*://i.redd.it/*",
+    ],
+    types: [
+      "main_frame",
+      "sub_frame",
+      "stylesheet",
+      "script",
+      "image",
+      "object",
+      "xmlhttprequest",
+      "other",
+    ],
+  },
+  [
+    "blocking",
+    "requestHeaders",
+  ]
+);

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "*://www.reddit.com/*",
     "*://np.reddit.com/*",
     "*://amp.reddit.com/*",
-    "*://i.reddit.com/*"
+    "*://i.reddit.com/*",
+    "*://i.redd.it/*"
   ]
 }


### PR DESCRIPTION
When loading a page as a document, browsers put HTML and other MIME types at the beginning of the Accept headers.
This is not the case for `<img>` tags.

Reddit abuses this to serve an HTML page on i.redd.it instead of the actual image when navigating directly to its URL.
Dropping the header restores the previous, sane behavior.

Fixes: #78