### PR TITLE
Stop HTML injection for preview.redd.it links

### DIFF
--- a/background.js
+++ b/background.js
@@ -53,15 +53,22 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
   function (details) {
     const url = new URL(details.url);
 
-    if (url.hostname === "i.redd.it") {
-      const headers = details.requestHeaders.filter(
-        (h) => h.name.toLowerCase() !== "accept"
-      );
-      return { requestHeaders: headers };
+    const imageUrlHostnames = [
+      "preview.redd.it",
+      "i.redd.it",
+    ]
+
+    for (const hostname of imageUrlHostnames) {
+      if (url.hostname === hostname) {
+        const headers = details.requestHeaders.filter(
+          (h) => h.name.toLowerCase() !== "accept"
+        );
+        return { requestHeaders: headers };
+      }
     }
   },
   {
-    urls: ["*://i.redd.it/*"],
+    urls: ["*://i.redd.it/*", "*://preview.redd.it/*"],
     types: [
       "main_frame",
       "sub_frame",

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
     "*://np.reddit.com/*",
     "*://amp.reddit.com/*",
     "*://i.reddit.com/*",
-    "*://i.redd.it/*"
+    "*://i.redd.it/*",
+    "*://preview.redd.it/*"
   ]
 }


### PR DESCRIPTION
Small modification to https://github.com/tom-james-watson/old-reddit-redirect/pull/79

preview.redd.it links also abuse the HTML injection mechanism to advertise their website. You can view examples of these URLs here (they seem to be mostly NSFW) https://old.reddit.com/domain/preview.redd.it/

