### PR TITLE
fix: redirect sh.reddit.com to old.reddit.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Also has a new minor fixes and quality of life improvements like:
 - `reddit.com`
 - `www.reddit.com`
 - `np.reddit.com`
+- `sh.reddit.com`
 - `amp.reddit.com`
 - `i.reddit.com`
 

--- a/background.js
+++ b/background.js
@@ -33,6 +33,7 @@ chrome.webRequest.onBeforeRequest.addListener(
       "*://reddit.com/*",
       "*://www.reddit.com/*",
       "*://np.reddit.com/*",
+      "*://sh.reddit.com/*",
       "*://amp.reddit.com/*",
       "*://i.reddit.com/*",
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
     "*://reddit.com/*",
     "*://www.reddit.com/*",
     "*://np.reddit.com/*",
+    "*://sh.reddit.com/*",
     "*://amp.reddit.com/*",
     "*://i.reddit.com/*",
     "*://i.redd.it/*",


### PR DESCRIPTION
sh.reddit.com seems to be a re-rewrite of their UI. They appear to be slowly rolling it out. 

I've tested it locally. Seems to be working. Please let me know if I've missed anything.