### PR TITLE
Exclude suspension appeals form from redirect

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,6 +7,7 @@ const excludedPaths = [
   /^\/topics/,
   /^\/community-points/,
   /^\/r\/[a-zA-Z0-9_]+\/s\/.*/, // eg https://reddit.com/r/comics/s/TjDGhcl22d
+  /^\/appeals?/,
 ];
 
 chrome.webRequest.onBeforeRequest.addListener(


### PR DESCRIPTION
The following pages are broken under the current redirect rules:

https://www.reddit.com/appeal
https://www.reddit.com/appeals