### PR TITLE
Get rid of "Block content on any page"

### DIFF
--- a/manifest-v3/manifest.json
+++ b/manifest-v3/manifest.json
@@ -13,7 +13,7 @@
       "css": ["styles.css"]
     }
   ],
-  "permissions": ["declarativeNetRequest"],
+  "permissions": ["declarativeNetRequestWithHostAccess"],
   "host_permissions": [
     "*://reddit.com/*",
     "*://www.reddit.com/*",


### PR DESCRIPTION
I'm not suuuper confident about this change, as I'm having a hard time understanding the [Mozilla](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest#permissions) and [Chrome](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest#permissions) docs.

Perhaps you can educate me?

It seems that Firefox treats declarativeNetRequestWithHostAccess as more reduced. That is, as only allowed to perform shenanigans on the host_permissions sites. So now Firefox no longer displays the "Block content on any page" (I assume same for Chrome, due to [this](https://developer.chrome.com/docs/extensions/reference/permissions-list#declarativeNetRequestWithHostAccess), though don't know how to check).

I replaced https with * for the prettiness hehe. Hope that's fine :)

On another note, though probably obvious at this point, the v3 version seems to work fine in Firefox!

![before](https://github.com/user-attachments/assets/c9625e22-63fc-40a0-aa05-492381ecd3d3)
![after](https://github.com/user-attachments/assets/9e26126a-95dd-4db3-b481-6763f5d5c759)