### PR TITLE
Exclude moderator URLs from redirect

### DIFF
--- a/manifest-v2/background.js
+++ b/manifest-v2/background.js
@@ -1,6 +1,7 @@
 const oldReddit = "https://old.reddit.com";
 const excludedPaths = [
   /^\/media/,
+  /^\/mod/,
   /^\/poll/,
   /^\/rpan/,
   /^\/settings/,

--- a/manifest-v3/rules.json
+++ b/manifest-v3/rules.json
@@ -6,7 +6,7 @@
       "type": "allow"
     },
     "condition": {
-      "regexFilter": "^https://\\w*\\.?reddit\\.com/(media|poll|settings|topics|community-points|appeals?|r/[a-zA-Z0-9_]+/s/).*",
+      "regexFilter": "^https://\\w*\\.?reddit\\.com/(media|mod|poll|settings|topics|community-points|appeals?|r/[a-zA-Z0-9_]+/s/).*",
       "resourceTypes": ["main_frame"]
     }
   },


### PR DESCRIPTION
When redirecting moderator URLs to old.reddit.com (https://www.reddit.com/mod/{subdomain}/insights you are redirected to a page not found error as insights are only available for the new design. 

This pull request resolves issue 106

https://github.com/tom-james-watson/old-reddit-redirect/issues/106