### PR TITLE
Mention all icon sizes in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,11 @@
     }
   },
   "icons": {
+    "16": "img/icon16.png",
+    "32": "img/icon32.png",
     "48": "img/icon48.png",
+    "64": "img/icon64.png",
+    "96": "img/icon96.png",
     "128": "img/icon128.png"
   },
   "content_scripts": [


### PR DESCRIPTION
Following up on #129

It seems I messed up while rebasing. Sorry!