### PR TITLE
Add redirect toolbar toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Also has a new minor fixes and quality of life improvements like:
 
 - Removing the undismissable cookie banner
 - Rewriting links to galleries to the raw old reddit comments page
+- One-click toolbar toggle to turn the redirect on/off
 
 #### Redirected domains
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Also has a new minor fixes and quality of life improvements like:
 
 - Removing the undismissable cookie banner
 - Rewriting links to galleries to the raw old reddit comments page
-- One-click toolbar toggle to turn the redirect on/off
+- Toolbar toggle to turn the redirect on/off
 
 #### Redirected domains
 

--- a/manifest.json
+++ b/manifest.json
@@ -18,13 +18,17 @@
     "96": "img/icon96.png",
     "128": "img/icon128.png"
   },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Old Reddit Redirect"
+  },
   "content_scripts": [
     {
       "matches": ["https://old.reddit.com/*"],
       "css": ["styles.css"]
     }
   ],
-  "permissions": ["declarativeNetRequestWithHostAccess"],
+  "permissions": ["declarativeNetRequestWithHostAccess", "storage"],
   "host_permissions": [
     "*://reddit.com/*",
     "*://www.reddit.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
       "css": ["styles.css"]
     }
   ],
-  "permissions": ["declarativeNetRequestWithHostAccess", "storage"],
+  "permissions": ["declarativeNetRequestWithHostAccess"],
   "host_permissions": [
     "*://reddit.com/*",
     "*://www.reddit.com/*",

--- a/popup.html
+++ b/popup.html
@@ -10,11 +10,21 @@
         padding: 8px 10px;
         font: 13px system-ui, -apple-system, Segoe UI, sans-serif;
       }
+
+      #status {
+        margin-bottom: 8px;
+      }
+
+      button {
+        width: 100%;
+        padding: 6px 10px;
+        font: inherit;
+      }
     </style>
   </head>
   <body>
-    <div id="status">Toggling…</div>
+    <div id="status">Loading…</div>
+    <button id="toggle" type="button" disabled>Toggle</button>
     <script src="popup.js"></script>
   </body>
 </html>
-

--- a/popup.html
+++ b/popup.html
@@ -7,23 +7,78 @@
     <style>
       body {
         margin: 0;
-        padding: 8px 10px;
-        font: 13px system-ui, -apple-system, Segoe UI, sans-serif;
+        min-width: 220px;
+        padding: 12px;
+        font: 13px "Segoe UI Variable", "Segoe UI", "SF Pro Text", "Noto Sans", sans-serif;
+        color: #2b2620;
+        background: linear-gradient(180deg, #f8f5ef 0%, #efe9df 100%);
+      }
+
+      .title {
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #7b6a55;
+        margin-bottom: 6px;
       }
 
       #status {
         margin-bottom: 8px;
+        font-weight: 600;
+      }
+
+      #status[data-state="on"] {
+        color: #7a3a14;
+      }
+
+      #status[data-state="off"] {
+        color: #1f4d7a;
       }
 
       button {
         width: 100%;
-        padding: 6px 10px;
+        padding: 8px 10px;
         font: inherit;
+        font-weight: 600;
+        border-radius: 8px;
+        border: 1px solid #d7c9b2;
+        background: #fff6e6;
+        color: #6b3b1f;
+        cursor: pointer;
+        transition: background 0.15s ease, border-color 0.15s ease, transform 0.05s ease;
+      }
+
+      button[data-state="off"] {
+        background: #e9f1ff;
+        border-color: #9ab8e0;
+        color: #1f4d7a;
+      }
+
+      button:hover {
+        background: #ffefd2;
+        border-color: #cfa887;
+      }
+
+      button[data-state="off"]:hover {
+        background: #dbe8ff;
+        border-color: #7ea4d9;
+      }
+
+      button:active {
+        transform: translateY(1px);
+      }
+
+      button:disabled {
+        cursor: default;
+        opacity: 0.7;
+        background: #f3eee6;
       }
     </style>
   </head>
   <body>
-    <div id="status">Loading…</div>
+    <div class="title">Old Reddit Redirect</div>
+    <div id="status">Loading...</div>
     <button id="toggle" type="button" disabled>Toggle</button>
     <script src="popup.js"></script>
   </body>

--- a/popup.html
+++ b/popup.html
@@ -7,79 +7,46 @@
     <style>
       body {
         margin: 0;
-        min-width: 220px;
-        padding: 12px;
-        font: 13px "Segoe UI Variable", "Segoe UI", "SF Pro Text", "Noto Sans", sans-serif;
-        color: #2b2620;
-        background: linear-gradient(180deg, #f8f5ef 0%, #efe9df 100%);
-      }
-
-      .title {
-        font-size: 11px;
-        font-weight: 600;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: #7b6a55;
-        margin-bottom: 6px;
-      }
-
-      #status {
-        margin-bottom: 8px;
-        font-weight: 600;
-      }
-
-      #status[data-state="on"] {
-        color: #7a3a14;
-      }
-
-      #status[data-state="off"] {
-        color: #1f4d7a;
+        min-width: 180px;
+        padding: 10px;
+        font: 13px system-ui, -apple-system, "Segoe UI", sans-serif;
+        color: #1a1a1b;
+        background: #fff6f2;
       }
 
       button {
         width: 100%;
-        padding: 8px 10px;
+        padding: 7px 8px;
         font: inherit;
         font-weight: 600;
-        border-radius: 8px;
-        border: 1px solid #d7c9b2;
-        background: #fff6e6;
-        color: #6b3b1f;
+        border-radius: 6px;
+        border: 1px solid #ff4500;
+        background: #ff4500;
+        color: #ffffff;
         cursor: pointer;
-        transition: background 0.15s ease, border-color 0.15s ease, transform 0.05s ease;
-      }
-
-      button[data-state="off"] {
-        background: #e9f1ff;
-        border-color: #9ab8e0;
-        color: #1f4d7a;
       }
 
       button:hover {
-        background: #ffefd2;
-        border-color: #cfa887;
-      }
-
-      button[data-state="off"]:hover {
-        background: #dbe8ff;
-        border-color: #7ea4d9;
-      }
-
-      button:active {
-        transform: translateY(1px);
+        background: #ff5c1a;
+        border-color: #ff5c1a;
       }
 
       button:disabled {
         cursor: default;
-        opacity: 0.7;
-        background: #f3eee6;
+        opacity: 0.6;
+        background: #ffd4c5;
+        border-color: #ffd4c5;
+        color: #7c3a24;
+      }
+
+      button:focus-visible {
+        outline: 2px solid #ff4500;
+        outline-offset: 2px;
       }
     </style>
   </head>
   <body>
-    <div class="title">Old Reddit Redirect</div>
-    <div id="status">Loading...</div>
-    <button id="toggle" type="button" disabled>Toggle</button>
+    <button id="toggle" type="button" disabled>Loading...</button>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Old Reddit Redirect</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 8px 10px;
+        font: 13px system-ui, -apple-system, Segoe UI, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="status">Toggling…</div>
+    <script src="popup.js"></script>
+  </body>
+</html>
+

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,65 @@
+const RULESET_ID = "ruleset_1";
+const STORAGE_KEY = "enabled";
+
+const statusElement = document.getElementById("status");
+
+function handleLastError() {
+  void chrome.runtime.lastError;
+}
+
+function setStatus(text) {
+  if (!statusElement) return;
+  statusElement.textContent = text;
+}
+
+function updateActionUi(enabled, done) {
+  chrome.action.setBadgeBackgroundColor({ color: "#d14343" }, () => {
+    handleLastError();
+    chrome.action.setBadgeText({ text: enabled ? "" : "OFF" }, () => {
+      handleLastError();
+      chrome.action.setTitle(
+        {
+          title: enabled
+            ? "Old Reddit Redirect is ON (click to turn off)"
+            : "Old Reddit Redirect is OFF (click to turn on)",
+        },
+        () => {
+          handleLastError();
+          done?.();
+        },
+      );
+    });
+  });
+}
+
+function updateRulesetState(enabled, done) {
+  chrome.declarativeNetRequest.updateEnabledRulesets(
+    enabled
+      ? { enableRulesetIds: [RULESET_ID], disableRulesetIds: [] }
+      : { enableRulesetIds: [], disableRulesetIds: [RULESET_ID] },
+    () => {
+      handleLastError();
+      done?.();
+    },
+  );
+}
+
+function toggleRedirect() {
+  chrome.storage.local.get({ [STORAGE_KEY]: true }, (items) => {
+    handleLastError();
+    const enabled = !Boolean(items[STORAGE_KEY]);
+
+    chrome.storage.local.set({ [STORAGE_KEY]: enabled }, () => {
+      handleLastError();
+      updateRulesetState(enabled, () => {
+        updateActionUi(enabled, () => {
+          setStatus(enabled ? "Redirect enabled" : "Redirect disabled");
+          window.close();
+        });
+      });
+    });
+  });
+}
+
+toggleRedirect();
+

--- a/popup.js
+++ b/popup.js
@@ -9,15 +9,22 @@ function handleLastError() {
   void chrome.runtime.lastError;
 }
 
-function setStatus(text) {
+function setStatus(text, state) {
   if (!statusElement) return;
   statusElement.textContent = text;
+
+  if (state) {
+    statusElement.dataset.state = state;
+  } else {
+    statusElement.removeAttribute("data-state");
+  }
 }
 
 function setToggleLabel(enabled) {
   if (!toggleButton) return;
   toggleButton.textContent = enabled ? "Disable redirect" : "Enable redirect";
   toggleButton.disabled = false;
+  toggleButton.dataset.state = enabled ? "on" : "off";
 }
 
 function updateActionUi(enabled, done) {
@@ -60,7 +67,7 @@ function toggleRedirect() {
     redirectEnabled = enabled;
 
     updateActionUi(enabled);
-    setStatus(enabled ? "Redirect is enabled" : "Redirect is disabled");
+    setStatus(enabled ? "Status: On" : "Status: Off", enabled ? "on" : "off");
     setToggleLabel(enabled);
   });
 }
@@ -72,7 +79,7 @@ function setRedirectEnabled(enabled) {
   updateRulesetState(enabled, () => {
     redirectEnabled = enabled;
     updateActionUi(enabled, () => {
-      setStatus(enabled ? "Redirect is enabled" : "Redirect is disabled");
+      setStatus(enabled ? "Status: On" : "Status: Off", enabled ? "on" : "off");
       setToggleLabel(enabled);
     });
   });

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,5 @@
 const RULESET_ID = "ruleset_1";
 
-const statusElement = document.getElementById("status");
 const toggleButton = document.getElementById("toggle");
 
 let redirectEnabled = null;
@@ -9,22 +8,10 @@ function handleLastError() {
   void chrome.runtime.lastError;
 }
 
-function setStatus(text, state) {
-  if (!statusElement) return;
-  statusElement.textContent = text;
-
-  if (state) {
-    statusElement.dataset.state = state;
-  } else {
-    statusElement.removeAttribute("data-state");
-  }
-}
-
 function setToggleLabel(enabled) {
   if (!toggleButton) return;
   toggleButton.textContent = enabled ? "Disable redirect" : "Enable redirect";
   toggleButton.disabled = false;
-  toggleButton.dataset.state = enabled ? "on" : "off";
 }
 
 function updateActionUi(enabled, done) {
@@ -67,7 +54,6 @@ function toggleRedirect() {
     redirectEnabled = enabled;
 
     updateActionUi(enabled);
-    setStatus(enabled ? "Status: On" : "Status: Off", enabled ? "on" : "off");
     setToggleLabel(enabled);
   });
 }
@@ -79,7 +65,6 @@ function setRedirectEnabled(enabled) {
   updateRulesetState(enabled, () => {
     redirectEnabled = enabled;
     updateActionUi(enabled, () => {
-      setStatus(enabled ? "Status: On" : "Status: Off", enabled ? "on" : "off");
       setToggleLabel(enabled);
     });
   });

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,4 @@
 const RULESET_ID = "ruleset_1";
-const STORAGE_KEY = "enabled";
 
 const statusElement = document.getElementById("status");
 
@@ -45,21 +44,18 @@ function updateRulesetState(enabled, done) {
 }
 
 function toggleRedirect() {
-  chrome.storage.local.get({ [STORAGE_KEY]: true }, (items) => {
+  chrome.declarativeNetRequest.getEnabledRulesets((rulesets) => {
     handleLastError();
-    const enabled = !Boolean(items[STORAGE_KEY]);
+    const enabledRulesets = Array.isArray(rulesets) ? rulesets : [];
+    const enabled = !enabledRulesets.includes(RULESET_ID);
 
-    chrome.storage.local.set({ [STORAGE_KEY]: enabled }, () => {
-      handleLastError();
-      updateRulesetState(enabled, () => {
-        updateActionUi(enabled, () => {
-          setStatus(enabled ? "Redirect enabled" : "Redirect disabled");
-          window.close();
-        });
+    updateRulesetState(enabled, () => {
+      updateActionUi(enabled, () => {
+        setStatus(enabled ? "Redirect enabled" : "Redirect disabled");
+        window.close();
       });
     });
   });
 }
 
 toggleRedirect();
-


### PR DESCRIPTION
Fixes #173

- Add a toolbar “Enable/Disable” popup.
- Toggles the DNR ruleset and updates toolbar icon/badge when toggled.

Tested (briefly) in chrome and firefox