### PR TITLE
Clean up regular expression in regexFilter

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -7,7 +7,7 @@
       "requestHeaders": [{ "header": "Accept", "operation": "remove" }]
     },
     "condition": {
-      "regexFilter": "^https://(i|preview).redd.it/*",
+      "regexFilter": "^https://(?:i|preview)\\.redd\\.it/",
       "resourceTypes": ["main_frame"]
     }
   },


### PR DESCRIPTION
Fix some minor nits:

- `(?:x)` Use non-capturing grouping
- Escape `.` wildcard
- `*` ist not a wildcard but kind of a repeater (the code says a "t" followed by 0-n "/").

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet

These are unlikely to cause real bugs and fix is just for the sake of cleaning up the code. No change in functionality.

Test:
For preview.reddit: https://www.reddit.com/r/pics/comments/1w23y29/old_lady_is_filled_up_on_smoked_pulled_pork_and/
For i.reddit: https://www.reddit.com/r/pics/comments/1w1owef/sunrise_today_on_lake_ontario/
