### PR TITLE
Fix extension not working in Firefox with first-party isolation enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
-.PHONY: run clean
+.PHONY: run run-isolated clean
 
 old-reddit-redirect.zip: *.json *.js *.html *.css img/* *.txt
 	zip -r old-reddit-redirect.zip * -x .git/* -x img/screenshot.png -x .gitignore -x Makefile -x _metadata/** -x "_metadata/*"
 
 run:
-	npx web-ext run
+	npx web-ext run \
+		--start-url www.reddit.com \
+		--devtools \
+		--pref devtools.toolbox.selectedTool=webconsole
+
+run-isolated:
+	npx web-ext run \
+		--start-url www.reddit.com \
+		--devtools \
+		--pref devtools.toolbox.selectedTool=webconsole \
+		--pref privacy.firstparty.isolate=true \
+		--pref privacy.userContext.enabled=true \
+		--pref privacy.userContext.ui.enabled=true
 
 clean:
 	rm -f *.zip

--- a/background.js
+++ b/background.js
@@ -69,8 +69,19 @@ const setOptOutCookieInStore = async (storeId) => {
         );
         return true;
     } catch (e) {
-        console.warn("failed to set opt-out cookie", e);
-        return false;
+        try {
+            // FPI could be on, set firstPartyDomain.
+            cookie.firstPartyDomain = cookie.domain;
+            await api.cookies.set(
+                withStore({ ...cookie, expirationDate }, storeId),
+            );
+            return true;
+        } catch (e) {
+            // Nope, that did not fix it. Revert.
+            cookie.firstPartyDomain = undefined;
+            console.warn("failed to set opt-out cookie", e);
+            return false;
+        }
     }
 };
 
@@ -81,10 +92,11 @@ const setOptOutCookie = async () => {
 };
 
 const removeOptOutCookie = async () => {
+    const { url, name, firstPartyDomain } = cookie;
     for (const storeId of await cookieStoreIds()) {
         try {
             await api.cookies.remove(
-                withStore({ url: cookie.url, name: cookie.name }, storeId),
+                withStore({ url, name, firstPartyDomain }, storeId),
             );
         } catch (e) {
             console.warn("failed to remove opt-out cookie", e);
@@ -143,8 +155,9 @@ api.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     }
 
     try {
+        const { url, name, firstPartyDomain } = cookie;
         const store = withStore(
-            { url: cookie.url, name: cookie.name },
+            { url, name, firstPartyDomain },
             tab.cookieStoreId,
         );
         const current = await api.cookies.get(store);

--- a/background.js
+++ b/background.js
@@ -4,7 +4,7 @@ const cookie = {
     url: "https://www.reddit.com/",
     name: "redesign_optout",
     value: "true",
-    domain: ".reddit.com",
+    domain: "reddit.com",
     path: "/",
     secure: true,
     sameSite: "lax",


### PR DESCRIPTION
Fixes #207.

At the moment, when starting the extension with privacy.firstparty.isolate=true, some calls to the cookie api result in an error as they require a firstPartyDomain attribute to be set but none is provided.

> When first-party isolation is on, you must provide this option or the API call fails and returns a rejected promise. For get(), set(), and remove() you must pass a string value. 

<img width="895" height="340" alt="image" src="https://github.com/user-attachments/assets/f77ac5c4-e7e5-49a4-a820-851e5c826e31" />
Screenshot shows output when launching with 

`npx web-ext run --devtools --start-url www.reddit.com --pref privacy.firstparty.isolate=true`

Always specifying a first-party domain attribute regardless of browser prefs results in the cookie not being sent to reddit when FPI is disabled.

Trigger the error when FPI is presumbly on, then add firstPartyDomain as needed.

See the docs [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).

I removed the leading dot in the domain as it *should* not have any effect any more accoring to mdn [docs](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie).

> Contrary to earlier specifications, leading dots in domain names are ignored, but browsers may decline to set the cookie containing such dots.

Also added `make run-isolated` as debugging shortcut.

Tested with Firefox 154.0.1.
Not tested with Google Chrome (doesn't support this type of isolation).

